### PR TITLE
Handle not found error with bom1 id

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Page not found</title>
+  <style>
+    :root { color-scheme: light dark; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Noto Sans", "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      display: grid;
+      min-height: 100vh;
+      place-items: center;
+      background: canvas;
+      color: canvastext;
+    }
+    main { padding: 2rem; text-align: center; max-width: 70ch; }
+    h1 { font-size: 2rem; margin: 0 0 0.5rem; }
+    p { margin: 0.25rem 0; opacity: 0.85; }
+    a { color: inherit; text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>404 — Page not found</h1>
+    <p>The page you requested does not exist.</p>
+    <p><a href="/">Go back home</a></p>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Site is live</title>
+  <style>
+    :root { color-scheme: light dark; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Noto Sans", "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      display: grid;
+      min-height: 100vh;
+      place-items: center;
+      background: canvas;
+      color: canvastext;
+    }
+    main { padding: 2rem; text-align: center; max-width: 70ch; }
+    h1 { font-size: 2rem; margin: 0 0 0.5rem; }
+    p { margin: 0.25rem 0; opacity: 0.85; }
+    code { padding: 0.1rem 0.3rem; border-radius: 4px; background: color-mix(in oklab, canvas, canvastext 10%); }
+    a { color: inherit; text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Deployment is live</h1>
+    <p>Your project is deployed and serving <code>index.html</code>.</p>
+    <p>Replace this file with your app, or add a framework and routes.</p>
+  </main>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Add basic `index.html`, `404.html`, and `vercel.json` to resolve a 404 NOT_FOUND error on an empty project.

The project was empty, leading to a 404 from the hosting platform. These files provide a minimal static site, a friendly 404 page, and Vercel-specific routing to ensure all requests are handled.

---
<a href="https://cursor.com/background-agent?bcId=bc-41f22e6c-bcb0-48b7-be27-7f90c614335e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41f22e6c-bcb0-48b7-be27-7f90c614335e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

