### PR TITLE
Decompose query into sub-queries

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -51,4 +51,9 @@ class Settings(BaseSettings):
     reranker_top_n: int = Field(default=5, alias="RERANKER_TOP_N")
     reranker_model: str = Field(default="cross-encoder/ms-marco-MiniLM-L-6-v2", alias="RERANKER_MODEL")
 
+    # Query decomposition
+    query_decomposition_enabled: bool = Field(default=True, alias="QUERY_DECOMPOSITION_ENABLED")
+    query_decomposition_max_sub_queries: int = Field(default=4, alias="QUERY_DECOMPOSITION_MAX_SUB_QUERIES")
+    query_decomposition_context_limit: int = Field(default=12, alias="QUERY_DECOMPOSITION_CONTEXT_LIMIT")
+
 settings = Settings()

--- a/backend/app/services/agents/__init__.py
+++ b/backend/app/services/agents/__init__.py
@@ -2,7 +2,12 @@ from .retrieval import RetrievalAgent
 from .analysis import AnalysisAgent
 from .visualization import VisualizationAgent
 from .forecasting import ForecastingAgent
+from .retrieval import RetrievalAgent
+from .analysis import AnalysisAgent
+from .visualization import VisualizationAgent
+from .forecasting import ForecastingAgent
 from .orchestrator import DataAnalysisAgent, AgentResponse
+from .decomposition import DecompositionAgent
 
 __all__ = [
     "RetrievalAgent",
@@ -11,4 +16,5 @@ __all__ = [
     "ForecastingAgent",
     "DataAnalysisAgent",
     "AgentResponse",
+    "DecompositionAgent",
 ]

--- a/backend/app/services/agents/analysis.py
+++ b/backend/app/services/agents/analysis.py
@@ -12,7 +12,7 @@ class AnalysisAgent:
     def __init__(self, *, llm: Optional[ChatOpenAI] = None):
         self.llm = llm or ChatOpenAI(api_key=settings.openai_api_key, model="gpt-4o-mini", temperature=0.2)
 
-    async def analyze(self, *, question: str, contexts: List[Dict[str, Any]]) -> Dict[str, Any]:
+    async def analyze(self, contexts: List[Dict[str, Any]], question: str) -> Dict[str, Any]:
         context_str = "\n\n".join(f"[{i+1}] {c.get('text','')}" for i, c in enumerate(contexts))
         messages = [
             SystemMessage(content=(

--- a/backend/app/services/agents/decomposition.py
+++ b/backend/app/services/agents/decomposition.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import List, Optional
+import json
+import re
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import SystemMessage, HumanMessage
+
+from ...core.config import settings
+
+
+class DecompositionAgent:
+    def __init__(self, *, llm: Optional[ChatOpenAI] = None, max_subqueries: Optional[int] = None):
+        self.llm = llm or ChatOpenAI(
+            api_key=settings.openai_api_key,
+            model="gpt-4o-mini",
+            temperature=0.1,
+        )
+        # Use config if present, else fallback
+        self.max_subqueries = (
+            max_subqueries
+            if max_subqueries is not None
+            else int(getattr(settings, "query_decomposition_max_sub_queries", 4))
+        )
+
+    async def decompose(self, *, question: str) -> List[str]:
+        should_decompose: bool = bool(getattr(settings, "query_decomposition_enabled", True))
+        if not should_decompose:
+            return [question]
+
+        if not settings.openai_api_key:
+            return self._fallback_split(question)
+
+        guidance = (
+            "Break the user question into at most N short, non-overlapping sub-questions that "
+            "together answer the original. Ensure each sub-question is self-contained. "
+            "Use the same language as the question. Output ONLY valid JSON as: {\"sub_queries\":[...]}"
+        )
+        n = max(1, min(8, self.max_subqueries))
+        messages = [
+            SystemMessage(content="You are a precise query planner."),
+            HumanMessage(content=f"N={n}\nQuestion: {question}\n\n{guidance}"),
+        ]
+        try:
+            resp = await self.llm.ainvoke(messages)
+            raw: str = (getattr(resp, "content", str(resp)) or "").strip()
+            cleaned = self._strip_fences(raw)
+            data = json.loads(cleaned)
+            subqs = data.get("sub_queries") if isinstance(data, dict) else None
+            if isinstance(subqs, list):
+                subqs = [s.strip() for s in subqs if isinstance(s, str) and s.strip()]
+                if subqs:
+                    return subqs[: n]
+        except Exception:
+            pass
+        return self._fallback_split(question)
+
+    def _fallback_split(self, question: str) -> List[str]:
+        text = (question or "").strip()
+        if not text:
+            return []
+        # Heuristic splits; keep concise and self-contained
+        candidates: List[str] = []
+        # Split by question marks
+        parts = [p.strip() for p in re.split(r"\?+\s*", text) if p.strip()]
+        if len(parts) > 1:
+            candidates.extend(parts)
+        else:
+            # Split on conjunctions/sequencers
+            tmp = re.split(r"\b(?:and then|then|after that|followed by|and)\b", text, flags=re.IGNORECASE)
+            tmp = [t.strip(", .;") for t in tmp if t and t.strip(", .;")]
+            candidates.extend(tmp or [text])
+        # Ensure max length and uniqueness
+        seen = set()
+        unique: List[str] = []
+        for c in candidates:
+            if c.lower() in seen:
+                continue
+            seen.add(c.lower())
+            unique.append(c if c.endswith('?') else c + '?')
+        return unique[: self.max_subqueries]
+
+    def _strip_fences(self, s: str) -> str:
+        s = s.strip()
+        if s.startswith("```") and s.endswith("```"):
+            s = s.strip("`")
+            # Remove optional language hint lines
+            lines = [ln for ln in s.splitlines() if ln.strip()]
+            if lines and not lines[0].startswith("{"):
+                lines = lines[1:]
+            return "\n".join(lines).strip()
+        return s

--- a/backend/app/services/agents/forecasting.py
+++ b/backend/app/services/agents/forecasting.py
@@ -27,3 +27,29 @@ class ForecastingAgent:
         content = getattr(resp, "content", str(resp)) or ""
         text = content.strip()
         return text if text else None
+
+    async def forecast(self, insights: Dict[str, Any]) -> Optional[str]:
+        """Forecast implications given computed insights.
+
+        Returns None if insufficient basis to forecast.
+        """
+        if not insights:
+            return None
+        question = insights.get("question") or ""
+        basis = (insights.get("explanation") or insights.get("answer") or "").strip()
+        if not basis:
+            return None
+        messages = [
+            SystemMessage(content=(
+                "Provide cautious short-term forecasts using only the given insight. "
+                "Make assumptions explicit and quantify uncertainty."
+            )),
+            HumanMessage(content=(
+                f"Question: {question}\n\nInsight basis:\n{basis}\n\n"
+                "Output: 3-5 bullet points forecasting implications."
+            )),
+        ]
+        resp = await self.llm.ainvoke(messages)
+        content = getattr(resp, "content", str(resp)) or ""
+        text = content.strip()
+        return text if text else None

--- a/backend/app/services/agents/orchestrator.py
+++ b/backend/app/services/agents/orchestrator.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
+import asyncio
 
 from .retrieval import RetrievalAgent
 from .analysis import AnalysisAgent
 from .visualization import VisualizationAgent
 from .forecasting import ForecastingAgent
+from .decomposition import DecompositionAgent
+from ...core.config import settings
 
 
 @dataclass
@@ -25,6 +28,10 @@ class DataAnalysisAgent:
         self.analysis_agent = AnalysisAgent()
         self.visualization_agent = VisualizationAgent()
         self.forecasting_agent = ForecastingAgent()
+        self.decomposition_agent = DecompositionAgent()
+
+    async def decompose_query(self, query: str) -> List[str]:
+        return await self.decomposition_agent.decompose(question=query)
 
     async def process_query(self, query: str, context: Dict[str, Any]):
         user_id: Optional[str] = (context or {}).get("user_id")
@@ -34,18 +41,47 @@ class DataAnalysisAgent:
         do_visualize: bool = bool((context or {}).get("visualize", False))
         do_forecast: bool = bool((context or {}).get("forecast", False))
 
-        # 1) Retrieve relevant context
-        sources = await self.retrieval_agent.retrieve(user_id=user_id, query=query)
+        # 1) Query decomposition (optional)
+        sub_queries: List[str]
+        if bool(getattr(settings, "query_decomposition_enabled", True)):
+            sub_queries = await self.decompose_query(query)
+            if not sub_queries:
+                sub_queries = [query]
+        else:
+            sub_queries = [query]
 
-        # 2) Analyze and answer
+        # 2) Retrieve relevant context (parallel over sub-queries)
+        if len(sub_queries) == 1:
+            sources = await self.retrieval_agent.retrieve(user_id=user_id, query=sub_queries[0])
+        else:
+            batches = await asyncio.gather(
+                *[self.retrieval_agent.retrieve(user_id=user_id, query=sq) for sq in sub_queries]
+            )
+            flat: List[Dict[str, Any]] = [item for batch in batches for item in batch]
+            # Deduplicate by text while preserving order; prefer higher score
+            best_by_text: Dict[str, Dict[str, Any]] = {}
+            for item in flat:
+                text_key = (item.get("text") or "").strip()
+                if not text_key:
+                    continue
+                prev = best_by_text.get(text_key)
+                if prev is None or (item.get("score") or float("-inf")) > (prev.get("score") or float("-inf")):
+                    best_by_text[text_key] = item
+            deduped = list(best_by_text.values())
+            # Sort by score desc, None last
+            deduped.sort(key=lambda x: (x.get("score") if x.get("score") is not None else float("-inf")), reverse=True)
+            limit = int(getattr(settings, "query_decomposition_context_limit", 12))
+            sources = deduped[:limit]
+
+        # 3) Analyze and answer
         analysis = await self.analysis_agent.analyze(question=query, contexts=sources)
 
-        # 3) Optional visualization
+        # 4) Optional visualization
         vis_spec: Optional[Dict[str, Any]] = None
         if do_visualize:
             vis_spec = await self.visualization_agent.maybe_visualize(question=query, contexts=sources)
 
-        # 4) Optional forecasting
+        # 5) Optional forecasting
         forecast_text: Optional[str] = None
         if do_forecast:
             forecast_text = await self.forecasting_agent.maybe_forecast(question=query, contexts=sources)

--- a/backend/app/services/agents/orchestrator.py
+++ b/backend/app/services/agents/orchestrator.py
@@ -50,28 +50,11 @@ class DataAnalysisAgent:
         else:
             sub_queries = [query]
 
-        # 2) Retrieve relevant context (parallel over sub-queries)
-        if len(sub_queries) == 1:
-            sources = await self.retrieval_agent.retrieve(user_id=user_id, query=sub_queries[0])
-        else:
-            batches = await asyncio.gather(
-                *[self.retrieval_agent.retrieve(user_id=user_id, query=sq) for sq in sub_queries]
-            )
-            flat: List[Dict[str, Any]] = [item for batch in batches for item in batch]
-            # Deduplicate by text while preserving order; prefer higher score
-            best_by_text: Dict[str, Dict[str, Any]] = {}
-            for item in flat:
-                text_key = (item.get("text") or "").strip()
-                if not text_key:
-                    continue
-                prev = best_by_text.get(text_key)
-                if prev is None or (item.get("score") or float("-inf")) > (prev.get("score") or float("-inf")):
-                    best_by_text[text_key] = item
-            deduped = list(best_by_text.values())
-            # Sort by score desc, None last
-            deduped.sort(key=lambda x: (x.get("score") if x.get("score") is not None else float("-inf")), reverse=True)
-            limit = int(getattr(settings, "query_decomposition_context_limit", 12))
-            sources = deduped[:limit]
+        # 2) Retrieve relevant context (delegate multi-query to RetrievalAgent)
+        sources = await self.retrieval_agent.retrieve(
+            user_id=user_id,
+            query=sub_queries if len(sub_queries) > 1 else sub_queries[0],
+        )
 
         # 3) Analyze and answer
         analysis = await self.analysis_agent.analyze(question=query, contexts=sources)

--- a/backend/app/services/agents/retrieval.py
+++ b/backend/app/services/agents/retrieval.py
@@ -1,23 +1,58 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 import asyncio
 
 from ..query_engine import build_hybrid_query_engine
+from ...core.config import settings
 
 
 class RetrievalAgent:
     def __init__(self, *, top_k: int | None = None):
         self.top_k = top_k
 
-    async def retrieve(self, *, user_id: str, query: str) -> List[Dict[str, Any]]:
+    async def retrieve(self, *, user_id: str, query: Union[str, List[str]]) -> List[Dict[str, Any]]:
+        """Retrieve context items for one or many queries.
+
+        When given a list of queries, executes in parallel and returns a
+        deduplicated, score-sorted list capped by a configurable limit.
+        """
         engine = build_hybrid_query_engine(user_id=user_id)
-        # LlamaIndex query is synchronous; run it in a thread to avoid blocking
-        response = await asyncio.to_thread(engine.query, query)
-        items: List[Dict[str, Any]] = []
-        for node in getattr(response, "source_nodes", []) or []:
-            text = node.get_content() if hasattr(node, "get_content") else getattr(node, "text", None)
-            metadata = getattr(node, "metadata", {})
-            score = getattr(node, "score", None)
-            items.append({"text": text, "metadata": metadata, "score": score})
-        return items
+
+        async def query_once(single_query: str) -> List[Dict[str, Any]]:
+            # LlamaIndex query is synchronous; run it in a thread to avoid blocking
+            response = await asyncio.to_thread(engine.query, single_query)
+            items: List[Dict[str, Any]] = []
+            for node in getattr(response, "source_nodes", []) or []:
+                text = node.get_content() if hasattr(node, "get_content") else getattr(node, "text", None)
+                metadata = getattr(node, "metadata", {})
+                score = getattr(node, "score", None)
+                items.append({"text": text, "metadata": metadata, "score": score})
+            return items
+
+        if isinstance(query, str):
+            return await query_once(query)
+
+        # Multiple sub-queries: fan-out, flatten, deduplicate, sort, cap
+        tasks = [query_once(q) for q in query if isinstance(q, str) and q.strip()]
+        if not tasks:
+            return []
+        batches = await asyncio.gather(*tasks)
+        flat: List[Dict[str, Any]] = [item for batch in batches for item in batch]
+
+        # Deduplicate by text; keep higher score when duplicates collide
+        best_by_text: Dict[str, Dict[str, Any]] = {}
+        for item in flat:
+            text_key = (item.get("text") or "").strip()
+            if not text_key:
+                continue
+            prev = best_by_text.get(text_key)
+            if prev is None or (item.get("score") or float("-inf")) > (prev.get("score") or float("-inf")):
+                best_by_text[text_key] = item
+        deduped = list(best_by_text.values())
+
+        # Sort by score desc; None scored items last
+        deduped.sort(key=lambda x: (x.get("score") if x.get("score") is not None else float("-inf")), reverse=True)
+
+        limit = int(getattr(settings, "query_decomposition_context_limit", 12))
+        return deduped[:limit]

--- a/backend/app/services/agents/visualization.py
+++ b/backend/app/services/agents/visualization.py
@@ -34,3 +34,36 @@ class VisualizationAgent:
         except Exception:
             return None
         return None
+
+    async def plan_visualizations(self, insights: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Plan one or more visualizations based on computed insights.
+
+        Returns a list of Vega-Lite v5 specs. Empty list if no helpful visuals.
+        """
+        if not insights:
+            return []
+        # If the analysis already contains a visualization hint/spec, surface it.
+        existing_spec = insights.get("visualization_spec")
+        if isinstance(existing_spec, dict):
+            return [existing_spec]
+        # Otherwise, attempt a single suggested chart based on the answer/explanation.
+        question = insights.get("question") or ""
+        context_hint = (insights.get("explanation") or insights.get("answer") or "").strip()
+        if not context_hint:
+            return []
+        messages = [
+            SystemMessage(content="Propose a concise chart to illustrate the key insight."),
+            HumanMessage(content=(
+                "Using the user's question and the analysis below, output ONLY a valid Vega-Lite v5 JSON spec.\n\n"
+                f"Question: {question}\n\nAnalysis:\n{context_hint}"
+            )),
+        ]
+        resp = await self.llm.ainvoke(messages)
+        raw = (getattr(resp, "content", str(resp)) or "").strip()
+        try:
+            spec = json.loads(raw)
+            if isinstance(spec, dict):
+                return [spec]
+        except Exception:
+            return []
+        return []


### PR DESCRIPTION
Implement optional query decomposition to break down complex queries into sub-queries for improved parallel retrieval.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fe1f0bc-87b5-4400-ba59-24392deb2c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6fe1f0bc-87b5-4400-ba59-24392deb2c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

