### PR TITLE
Investigate npm run build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@app/root",
+  "private": true,
+  "scripts": {
+    "build": "npm --prefix frontend ci && npm --prefix frontend run build",
+    "dev": "npm --prefix frontend run dev",
+    "start": "npm --prefix frontend run start",
+    "lint": "npm --prefix frontend run lint"
+  }
+}


### PR DESCRIPTION
Add a root `package.json` to proxy build commands to the `frontend` app, resolving the "npm run build exited with 1" error in CI.

The build was failing because CI was attempting to run `npm run build` at the repository root, where no `package.json` existed. The actual application and its `package.json` are located in the `frontend` subdirectory. This change introduces a root `package.json` that simply forwards these commands to the correct `frontend` directory, allowing the build to succeed.

---
<a href="https://cursor.com/background-agent?bcId=bc-556d08e3-dc55-461f-98c2-5123cb0feef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-556d08e3-dc55-461f-98c2-5123cb0feef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

