### PR TITLE
Debug react error and analytics script

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
 import { Analytics } from "@vercel/analytics/react";
+import { ColorModeScript } from "@chakra-ui/react";
+import theme from "@/theme";
 import Navbar from "@/components/Navbar";
 
 const geistSans = Geist({
@@ -26,12 +28,13 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ColorModeScript initialColorMode={theme.config.initialColorMode} />
         <Providers>
           <Navbar />
           {children}
-          <Analytics />
+          {process.env.NODE_ENV === 'production' && <Analytics />}
         </Providers>
       </body>
     </html>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import Providers from "./providers";
 import { Analytics } from "@vercel/analytics/react";
 import { ColorModeScript } from "@chakra-ui/react";
-import theme from "@/theme";
+import { themeConfig } from "@/theme/config";
 import Navbar from "@/components/Navbar";
 
 const geistSans = Geist({
@@ -30,7 +30,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+        <ColorModeScript initialColorMode={themeConfig.initialColorMode} />
         <Providers>
           <Navbar />
           {children}

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ReactNode } from 'react';
-import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
+import { ChakraProvider } from '@chakra-ui/react';
 import theme from '@/theme';
 
 type ProvidersProps = {
@@ -11,7 +11,6 @@ type ProvidersProps = {
 export default function Providers({ children }: ProvidersProps) {
   return (
     <ChakraProvider theme={theme}>
-      <ColorModeScript initialColorMode={theme.config.initialColorMode} />
       {children}
     </ChakraProvider>
   );

--- a/frontend/theme/config.ts
+++ b/frontend/theme/config.ts
@@ -1,0 +1,6 @@
+import type { ThemeConfig } from '@chakra-ui/react';
+
+export const themeConfig: ThemeConfig = {
+  initialColorMode: 'system',
+  useSystemColorMode: true,
+};

--- a/frontend/theme/index.ts
+++ b/frontend/theme/index.ts
@@ -1,12 +1,8 @@
-import { extendTheme, ThemeConfig } from '@chakra-ui/react';
-
-const config: ThemeConfig = {
-  initialColorMode: 'system',
-  useSystemColorMode: true,
-};
+import { extendTheme } from '@chakra-ui/react';
+import { themeConfig } from './config';
 
 const theme = extendTheme({
-  config,
+  config: themeConfig,
 });
 
 export default theme;


### PR DESCRIPTION
Fix React hydration error by moving `ColorModeScript` to `layout.tsx` and prevent Vercel Analytics 404 in development environments.

The React hydration error #418 occurred because `ColorModeScript` was rendered inside a client-side component, causing a mismatch between server-rendered and client-rendered HTML. Moving it directly into the `<body>` in `layout.tsx` resolves this. The Vercel Analytics 404 was due to the script only being available in production Vercel deployments, so it's now conditionally rendered.

---
<a href="https://cursor.com/background-agent?bcId=bc-199f41b1-66f0-4540-a3dd-b20594ca2b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-199f41b1-66f0-4540-a3dd-b20594ca2b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

