### PR TITLE
Debug missing bearer token error

### DIFF
--- a/frontend/app/api/analyze/route.ts
+++ b/frontend/app/api/analyze/route.ts
@@ -27,7 +27,12 @@ export async function POST(req: NextRequest) {
     const headers: Record<string, string> = {
       'content-type': 'application/json',
     };
-    const authToken = process.env.BACKEND_BEARER_TOKEN || process.env.NEXT_PUBLIC_BACKEND_BEARER_TOKEN;
+    const authToken =
+      process.env.BACKEND_BEARER_TOKEN ||
+      process.env.BACKEND_AUTH_BEARER_TOKEN ||
+      process.env.NEXT_PUBLIC_BACKEND_BEARER_TOKEN ||
+      process.env.AUTH_BEARER_TOKEN ||
+      process.env.NEXT_PUBLIC_AUTH_BEARER_TOKEN;
     if (authToken) headers['authorization'] = `Bearer ${authToken}`;
 
     const res = await fetch(`${backend}/api/v1/agents/analyze`, {

--- a/frontend/app/api/health/route.ts
+++ b/frontend/app/api/health/route.ts
@@ -12,7 +12,12 @@ export async function GET() {
   try {
     const backend = getBackendBaseUrl();
     const headers: Record<string, string> = {};
-    const authToken = process.env.BACKEND_BEARER_TOKEN || process.env.NEXT_PUBLIC_BACKEND_BEARER_TOKEN;
+    const authToken =
+      process.env.BACKEND_BEARER_TOKEN ||
+      process.env.BACKEND_AUTH_BEARER_TOKEN ||
+      process.env.NEXT_PUBLIC_BACKEND_BEARER_TOKEN ||
+      process.env.AUTH_BEARER_TOKEN ||
+      process.env.NEXT_PUBLIC_AUTH_BEARER_TOKEN;
     if (authToken) headers['authorization'] = `Bearer ${authToken}`;
 
     const res = await fetch(`${backend}/api/v1/health`, { headers, cache: 'no-store' });

--- a/frontend/app/api/ingest/upload/route.ts
+++ b/frontend/app/api/ingest/upload/route.ts
@@ -30,7 +30,13 @@ export async function POST(req: NextRequest) {
     }
 
     const headers: Record<string, string> = {};
-    const authToken = process.env.BACKEND_BEARER_TOKEN || process.env.NEXT_PUBLIC_BACKEND_BEARER_TOKEN;
+    // Support multiple env var names to reduce misconfig risk across platforms
+    const authToken =
+      process.env.BACKEND_BEARER_TOKEN ||
+      process.env.BACKEND_AUTH_BEARER_TOKEN ||
+      process.env.NEXT_PUBLIC_BACKEND_BEARER_TOKEN ||
+      process.env.AUTH_BEARER_TOKEN ||
+      process.env.NEXT_PUBLIC_AUTH_BEARER_TOKEN;
     if (authToken) headers['authorization'] = `Bearer ${authToken}`;
 
     const res = await fetch(`${backend}/api/v1/ingest/upload`, {


### PR DESCRIPTION
Update frontend API routes to check for additional environment variable names for the bearer token to prevent authentication misconfigurations.

The original setup caused 401 errors due to a mismatch in expected environment variable names for the bearer token between the backend (`AUTH_BEARER_TOKEN`) and the frontend proxy (`BACKEND_BEARER_TOKEN`). This change broadens the accepted environment variable names in the frontend to improve compatibility and reduce common authentication setup issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-3adf7a31-bddb-4354-aa6a-d8e8356ccda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3adf7a31-bddb-4354-aa6a-d8e8356ccda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

