### PR TITLE
Handle data ingestion upload 404 error

### DIFF
--- a/404_FIX_SUMMARY.md
+++ b/404_FIX_SUMMARY.md
@@ -1,0 +1,129 @@
+# 404 Error Fix Summary
+
+## Problem
+The `/api/ingest/upload` endpoint was returning a 404 error when deployed on Vercel.
+
+## Root Cause
+The `vercel.json` configuration had a problematic routing setup:
+```json
+{
+  "builds": [
+    { "src": "frontend/package.json", "use": "@vercel/next" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "frontend/$1" }
+  ]
+}
+```
+
+This custom routing configuration was interfering with Next.js App Router's automatic API route handling.
+
+## Solution Applied
+Updated `vercel.json` to use the proper monorepo configuration:
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd frontend && npm run build",
+  "installCommand": "cd frontend && npm install",
+  "framework": "nextjs",
+  "outputDirectory": "frontend/.next"
+}
+```
+
+### Key Changes:
+1. **Removed custom routes**: The `routes` array was deleted as Next.js handles routing automatically
+2. **Removed old builds config**: Replaced with explicit build commands
+3. **Added framework specification**: Explicitly tells Vercel this is a Next.js project
+4. **Proper monorepo setup**: Commands navigate to the `frontend` directory before running
+
+## Next Steps
+
+### 1. Redeploy to Vercel
+You need to trigger a new deployment for the changes to take effect:
+
+**Option A: Via Git (Recommended)**
+```bash
+git add vercel.json
+git commit -m "fix: Update Vercel config to fix API route 404 errors"
+git push
+```
+
+**Option B: Via Vercel CLI**
+```bash
+vercel --prod
+```
+
+**Option C: Via Vercel Dashboard**
+- Go to your Vercel project dashboard
+- Navigate to the Deployments tab
+- Click "Redeploy" on the latest deployment
+
+### 2. Verify the Fix
+After deployment, test the endpoint:
+```bash
+curl -X POST https://your-app.vercel.app/api/ingest/upload \
+  -F "file=@test.csv" \
+  -F "user_id=test-user"
+```
+
+### 3. Alternative: Configure Root Directory in Vercel Dashboard
+If you prefer, you can also set the root directory in the Vercel project settings:
+1. Go to Project Settings → General
+2. Set "Root Directory" to `frontend`
+3. This would allow you to simplify `vercel.json` or remove it entirely
+
+## API Route Structure (Verified Correct)
+```
+frontend/
+  app/
+    api/
+      analyze/route.ts          → /api/analyze
+      health/route.ts           → /api/health
+      ingest/
+        upload/route.ts         → /api/ingest/upload  ✓
+      export/
+        pdf/route.ts            → /api/export/pdf
+        image/route.ts          → /api/export/image
+```
+
+All routes are properly structured and export the correct HTTP method handlers.
+
+## Technical Details
+
+### Why the Old Config Failed
+The `"routes": [{ "src": "/(.*)", "dest": "frontend/$1" }]` configuration was trying to do static routing, but Next.js App Router needs dynamic routing to handle API routes. The custom route rule was overriding Next.js's internal routing mechanism.
+
+### How the New Config Works
+- **Build Command**: `cd frontend && npm run build` ensures Next.js builds from the correct directory
+- **Framework Detection**: `"framework": "nextjs"` tells Vercel to use Next.js-specific deployment logic
+- **Output Directory**: `"outputDirectory": "frontend/.next"` tells Vercel where to find the build output
+- Vercel automatically handles routing for Next.js API routes without explicit route rules
+
+## Verification Checklist
+After redeployment, verify:
+- [ ] `/api/ingest/upload` returns proper response (not 404)
+- [ ] `/api/analyze` still works
+- [ ] `/api/health` still works
+- [ ] `/api/export/pdf` still works
+- [ ] `/api/export/image` still works
+- [ ] Frontend pages still load correctly
+
+## Additional Notes
+
+### Environment Variables
+Ensure these environment variables are set in Vercel:
+- `BACKEND_URL` or `NEXT_PUBLIC_BACKEND_URL`
+- `BACKEND_BEARER_TOKEN` or similar auth token variables
+
+### Runtime Configuration
+All API routes are configured with:
+- `runtime: 'nodejs'` - Uses Node.js runtime
+- `dynamic: 'force-dynamic'` - Disables caching for dynamic responses
+- `preferredRegion: ['iad1', 'cdg1']` - (for some routes) Specifies deployment regions
+
+## Support
+If the issue persists after redeployment:
+1. Check Vercel build logs for errors
+2. Verify environment variables are set correctly
+3. Ensure the backend service is accessible from Vercel's network
+4. Check for any custom middleware that might be blocking requests

--- a/test-upload-endpoint.sh
+++ b/test-upload-endpoint.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Test script for the /api/ingest/upload endpoint
+# Usage: ./test-upload-endpoint.sh [your-app-url]
+
+# Color codes for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Default to localhost if no URL provided
+APP_URL="${1:-http://localhost:3000}"
+
+echo -e "${YELLOW}Testing upload endpoint at: ${APP_URL}/api/ingest/upload${NC}\n"
+
+# Create a test CSV file
+echo "Creating test CSV file..."
+cat > test-data.csv << 'EOF'
+id,product,sales,date
+1,Widget A,1500,2024-01-15
+2,Widget B,2300,2024-01-16
+3,Widget C,1800,2024-01-17
+4,Widget A,2100,2024-01-18
+5,Widget B,1900,2024-01-19
+EOF
+
+echo -e "${GREEN}✓ Test file created: test-data.csv${NC}\n"
+
+# Test the endpoint
+echo "Testing upload endpoint..."
+echo "----------------------------------------"
+
+RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+  -X POST "${APP_URL}/api/ingest/upload" \
+  -F "file=@test-data.csv" \
+  -F "user_id=test-user-123")
+
+HTTP_CODE=$(echo "$RESPONSE" | grep "HTTP_CODE:" | cut -d: -f2)
+BODY=$(echo "$RESPONSE" | sed '/HTTP_CODE:/d')
+
+echo "Response:"
+echo "$BODY" | python3 -m json.tool 2>/dev/null || echo "$BODY"
+echo ""
+echo "HTTP Status Code: $HTTP_CODE"
+echo "----------------------------------------"
+
+# Check result
+if [ "$HTTP_CODE" = "200" ]; then
+    echo -e "\n${GREEN}✓ SUCCESS! Upload endpoint is working correctly.${NC}"
+    exit 0
+elif [ "$HTTP_CODE" = "404" ]; then
+    echo -e "\n${RED}✗ ERROR: 404 Not Found${NC}"
+    echo -e "${YELLOW}The endpoint is still not found. This usually means:${NC}"
+    echo "  1. The deployment hasn't been triggered yet"
+    echo "  2. The vercel.json changes haven't been deployed"
+    echo "  3. The API route is not being built correctly"
+    echo ""
+    echo -e "${YELLOW}Next steps:${NC}"
+    echo "  1. Make sure you've committed and pushed the vercel.json changes"
+    echo "  2. Trigger a new deployment on Vercel"
+    echo "  3. Check Vercel build logs for any errors"
+    exit 1
+else
+    echo -e "\n${YELLOW}⚠ Warning: Got HTTP $HTTP_CODE${NC}"
+    echo "This might indicate an issue with the backend or configuration."
+    exit 1
+fi

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,7 @@
 {
-  "builds": [
-    { "src": "frontend/package.json", "use": "@vercel/next" }
-  ],
-  "routes": [
-    { "src": "/(.*)", "dest": "frontend/$1" }
-  ]
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd frontend && npm run build",
+  "installCommand": "cd frontend && npm install",
+  "framework": "nextjs",
+  "outputDirectory": "frontend/.next"
 }


### PR DESCRIPTION
Update `vercel.json` to correctly configure Vercel for a Next.js monorepo, resolving 404 errors for API routes.

The previous `vercel.json` included a custom `routes` array that was overriding Next.js's automatic API route handling, leading to 404 errors for endpoints like `/api/ingest/upload`. This change removes the problematic routing rules and explicitly defines the build and install commands, framework, and output directory for proper Vercel deployment of the Next.js application within the `frontend` subdirectory.

---
<a href="https://cursor.com/background-agent?bcId=bc-19b863ec-4840-4494-a31b-3acfe9df8979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19b863ec-4840-4494-a31b-3acfe9df8979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

