### PR TITLE
Update vercel json output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,7 @@
 {
-  "builds": [
-    { "src": "frontend/package.json", "use": "@vercel/next" }
-  ],
-  "routes": [
-    { "src": "/(.*)", "dest": "frontend/$1" }
-  ]
+  "buildCommand": "cd frontend && npm ci && npm run build",
+  "outputDirectory": "frontend/.next",
+  "installCommand": "npm install",
+  "framework": "nextjs",
+  "devCommand": "cd frontend && npm run dev"
 }


### PR DESCRIPTION
Update `vercel.json` to correctly configure Vercel deployment for a Next.js app in a `frontend/` subdirectory, resolving the 'No Output Directory' error.

The previous `vercel.json` used a deprecated `builds` API and expected a `public` output directory, which is incorrect for Next.js applications (which output to `.next`). This PR updates the configuration to use modern Vercel settings, specify the correct build and output paths (`frontend/.next`), and set the framework to `nextjs` for proper optimization.

---
<a href="https://cursor.com/background-agent?bcId=bc-3099e615-17db-425c-8db0-9a488a308c6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3099e615-17db-425c-8db0-9a488a308c6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

