### PR TITLE
Configure ai backend and frontend deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -15,8 +15,6 @@ services:
     startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
     healthCheckPath: /api/v1/health
     autoDeploy: true
-    envVarGroups:
-      - shared-auth
     envVars:
       - key: ENVIRONMENT
         value: production
@@ -24,6 +22,8 @@ services:
         fromDatabase:
           name: ai-db
           property: connectionString
+      - fromGroup:
+          name: shared-auth
 
   - type: web
     name: ai-frontend
@@ -33,8 +33,6 @@ services:
     buildCommand: npm ci && npm run build
     startCommand: npm run start
     autoDeploy: true
-    envVarGroups:
-      - shared-auth
     envVars:
       - key: BACKEND_URL
         fromService:
@@ -46,6 +44,8 @@ services:
           name: ai-backend
           type: web
           property: url
+      - fromGroup:
+          name: shared-auth
 
 databases:
   - name: ai-db

--- a/render.yaml
+++ b/render.yaml
@@ -32,6 +32,7 @@ services:
     rootDir: frontend
     buildCommand: npm ci && npm run build
     startCommand: npm run start
+    healthCheckPath: /api/health
     autoDeploy: true
     envVars:
       - key: BACKEND_URL

--- a/test_render_yaml.py
+++ b/test_render_yaml.py
@@ -121,8 +121,16 @@ def test_services(data):
         # Check environment variables
         if 'envVars' in service:
             for var in service['envVars']:
+                # Support either key-based env var or fromGroup (which has no 'key')
+                if 'fromGroup' in var:
+                    grp = var['fromGroup']
+                    if not isinstance(grp, dict) or 'name' not in grp:
+                        print(f"  ✗ Service '{service['name']}' has invalid fromGroup reference")
+                        return False
+                    continue
+
                 if 'key' not in var:
-                    print(f"  ✗ Service '{service['name']}' has envVar without 'key'")
+                    print(f"  ✗ Service '{service['name']}' has envVar without 'key' (and not fromGroup)")
                     return False
                 
                 # Check that envVar has a value source

--- a/verify_config.py
+++ b/verify_config.py
@@ -59,6 +59,10 @@ def main():
         if 'envVars' in service:
             print(f"     └─ Environment Variables:")
             for var in service['envVars']:
+                if 'fromGroup' in var and isinstance(var['fromGroup'], dict):
+                    grp = var['fromGroup']
+                    print(f"        ├─ ← Group:{grp.get('name')}")
+                    continue
                 key = var['key']
                 if 'value' in var:
                     print(f"        ├─ {key} = {var['value']}")


### PR DESCRIPTION
Refactor service-level environment variable group references in `render.yaml` to use `envVars` with `fromGroup` syntax, resolving blueprint validation errors.

The previous `envVarGroups` syntax at the service level was causing validation errors in the Render blueprint. This change adopts the supported pattern of referencing environment variable groups via `envVars` with a `fromGroup` object, ensuring correct configuration and eliminating the reported errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c427daa-9d5b-4d54-aaf1-d19aa5bb16a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c427daa-9d5b-4d54-aaf1-d19aa5bb16a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

