### PR TITLE
Resolve nextjs multiple lockfile warning

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,10 @@
 import type { NextConfig } from "next";
+import { join } from "path";
 
 const nextConfig: NextConfig = {
+  // Ensure Next.js traces files from the monorepo root to avoid
+  // multiple lockfile workspace inference warnings
+  outputFileTracingRoot: join(process.cwd(), ".."),
   experimental: {
     optimizePackageImports: [
       "@chakra-ui/react",


### PR DESCRIPTION
Set `outputFileTracingRoot` in `frontend/next.config.ts` to silence Next.js warnings about multiple lockfiles.

---
<a href="https://cursor.com/background-agent?bcId=bc-000f54e4-7149-4985-acde-67720f19a581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-000f54e4-7149-4985-acde-67720f19a581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

